### PR TITLE
fix: change naming of release products

### DIFF
--- a/.github/workflows/build_and_push.yaml
+++ b/.github/workflows/build_and_push.yaml
@@ -21,6 +21,8 @@ jobs:
   build_and_push_docker:
       uses: MapColonies/shared-workflows/.github/workflows/build-and-push-docker.yaml@master
       secrets: inherit
+      with:
+        reopistory: pp-geoserver-side-car
   
   build_and_push_helm:
       uses: MapColonies/shared-workflows/.github/workflows/build-and-push-helm.yaml@master


### PR DESCRIPTION
sidr-car image will be pushed as "pp-geoserver-side-car"

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |
