### PR TITLE
helm: upgraded nginx to v2.2.1

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -6,7 +6,7 @@ appVersion: 3.2.0
 description: Chart for geoserver in openshift
 dependencies:
   - name: nginx
-    version: 2.1.6
+    version: 2.2.1
     repository: oci://acrarolibotnonprod.azurecr.io/helm/common
     condition: enabled
   - name: mclabels

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -179,7 +179,7 @@ nginx:
   fullnameOverride: ""
   image:
     repository: common/nginx
-    tag: 'v2.1.6'
+    tag: 'v2.2.1'
   extensions:
     server:
       enabled: true

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -176,7 +176,7 @@ sideCar:
 nginx:
   enabled: true
   replicaCount: 1
-  fullnameOverride: ""
+  nameOverride: "pycsw-nginx"
   image:
     repository: common/nginx
     tag: 'v2.2.1'

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -176,7 +176,7 @@ sideCar:
 nginx:
   enabled: true
   replicaCount: 1
-  nameOverride: "pycsw-nginx"
+  nameOverride: "pp-geoserver-nginx"
   image:
     repository: common/nginx
     tag: 'v2.2.1'


### PR DESCRIPTION
This pull request updates the nginx dependency used by the Helm chart to a newer version and customizes the deployment configuration for nginx. The most important changes are:

**Dependency Updates:**
* Upgraded the `nginx` Helm chart dependency version from `2.1.6` to `2.2.1` in `helm/Chart.yaml` to ensure the use of the latest features and security patches.

**Configuration Changes:**
* Updated the nginx container image tag from `v2.1.6` to `v2.2.1` in `helm/values.yaml` to match the chart version.
* Set `nameOverride` to `"pycsw-nginx"` for the nginx deployment in `helm/values.yaml` to customize the release name.