### PR TITLE
chore(helm): upgrade nginx chart to 2.3.1 and drop pinned image tag

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -6,7 +6,7 @@ appVersion: 3.3.0
 description: Chart for geoserver in openshift
 dependencies:
   - name: nginx
-    version: 2.2.1
+    version: 2.3.1
     repository: oci://acrarolibotnonprod.azurecr.io/helm/common
     condition: enabled
   - name: mclabels

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -17,7 +17,7 @@ mclabels:
   prometheus:
     enabled: true
     port: 9117
-  longScraping: true
+  logScraping: true
 
 cloudProvider:
   dockerRegistryUrl: my-registry-url.io

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -179,7 +179,6 @@ nginx:
   nameOverride: "pp-geoserver-nginx"
   image:
     repository: common/nginx
-    tag: 'v2.2.1'
   extensions:
     server:
       enabled: true


### PR DESCRIPTION
## Description

- Upgrade the `nginx` chart dependency in `helm/Chart.yaml` from 2.2.1 to 2.3.1.
- Remove the pinned `nginx.image.tag` from `helm/values.yaml` so the image tag falls back to the chart's default.