### PR TITLE
feat(helm): add disableCors flag rendering DISABLE_CORS (MAPCO-11397)

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -17,6 +17,25 @@
 > [!IMPORTANT]
 > PROXY_BASE_URL must be changed according to deployed route.
 
+### CORS
+Two layers can emit CORS response headers: the nginx sub-chart (which always adds them at
+server level) and GeoServer itself (Tomcat's `CorsFilter`, enabled by default in the
+kartoza-based image). Behind nginx that yields two `Access-Control-Allow-Origin` headers.
+
+`disableCors` turns GeoServer's own handling off, leaving nginx as the single source:
+
+```yaml
+disableCors: true
+```
+
+It renders the `DISABLE_CORS` env var into the ConfigMap, which the geoserver container
+consumes via `envFrom`. The image's entrypoint comments the `CorsFilter` out of
+`conf/web.xml` when it is `true`. Defaults to `false`, preserving current behaviour.
+
+> [!NOTE]
+> The entrypoint rewrites `web.xml` on container start, so an existing pod must be
+> restarted for a change to this value to take effect.
+
 
 ## Deployment
 

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -18,6 +18,7 @@ data:
   UPDATE_INTERVAL: {{ .Values.updateInterval | default 120000 | quote }}
   INITIAL_MEMORY: {{ .Values.initialMemory | default "128M" | quote }}
   MAX_MEMORY: {{ .Values.maxMemory | default "756M" | quote }}
+  DISABLE_CORS: {{ .Values.disableCors | default false | quote }}
   GEOSERVER_DATA_DIR: {{ $fs.internalPvc.mountPath | quote }}
   POLLING_INTERVAL_MS: {{ .Values.sideCar.env.pollingIntervalMs | default 3000 | quote }}
   GEOSERVER_BASE_URL: {{ $serviceUrls.geoserverUrl | quote }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -52,6 +52,10 @@ fullnameOverride: pp-geoserver
 initialMemory: "128M"
 maxMemory: "756M"
 
+# Disables GeoServer's own CORS handling (Tomcat CorsFilter), leaving the
+# nginx front layer as the single source of CORS response headers.
+disableCors: false
+
 storage:
   fs:
     internalPvc:


### PR DESCRIPTION
| Question         | Answer |
| ---------------- | ------ |
| Bug fix          | ✖      |
| New feature      | ✔      |
| Breaking change  | ✖      |
| Deprecations     | ✖      |
| Documentation    | ✔      |
| Tests added      | ✖      |
| Chore            | ✖      |

Related issues: MAPCO-11397

Further information:

Adds a `disableCors` chart value, defaulting to `false`, rendered as the `DISABLE_CORS` env var into the ConfigMap that the `geoserver-os` container consumes via `envFrom`.

### Why `DISABLE_CORS` and not `CORS_ENABLED`

`MapColonies/geoserver` is a thin wrapper that clones `kartoza/docker-geoserver` and strips the `VOLUME []` command, so the image keeps kartoza's env contract. At the deployed tag (`v2.0.0-2.26.0` → kartoza 2.26.0) that contract is `DISABLE_CORS`, not `CORS_ENABLED`:

- `scripts/env-data.sh` defaults `DISABLE_CORS=false`
- `scripts/functions.sh` comments Tomcat's `CorsFilter` out of `conf/web.xml` when it matches `true` (case-insensitive)
- `build_data/web.xml` carries the `CORS_START` / `CORS_END` markers that the `sed` targets

So the value name in the parent issue maps straight through to the image with no translation.

### Behaviour

Default `false` preserves exactly what is deployed today. With `true`, GeoServer stops emitting its own CORS response headers, leaving the nginx sub-chart as the single source of them.

> [!NOTE]
> The entrypoint rewrites `web.xml` on container start, so an existing pod must be restarted for a change to take effect. This is documented in `helm/README.md`.

### Verification

```
$ helm template t helm/
  DISABLE_CORS: "false"

$ helm template t helm/ --set disableCors=true
  DISABLE_CORS: "true"
```

`helm lint`, `prettier --check`, and `eslint` all pass.

Followed by #54, which suppresses any CORS header GeoServer still sends at the nginx layer.
