### PR TITLE
feat(helm): hide GeoServer CORS headers at nginx when disableCors is on (MAPCO-11397)

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -22,7 +22,7 @@ Two layers can emit CORS response headers: the nginx sub-chart (which always add
 server level) and GeoServer itself (Tomcat's `CorsFilter`, enabled by default in the
 kartoza-based image). Behind nginx that yields two `Access-Control-Allow-Origin` headers.
 
-`disableCors` turns GeoServer's own handling off, leaving nginx as the single source:
+`disableCors` turns GeoServer's own handling off, so only nginx's headers remain:
 
 ```yaml
 disableCors: true
@@ -30,11 +30,24 @@ disableCors: true
 
 It renders the `DISABLE_CORS` env var into the ConfigMap, which the geoserver container
 consumes via `envFrom`. The image's entrypoint comments the `CorsFilter` out of
-`conf/web.xml` when it is `true`. Defaults to `false`, preserving current behaviour.
+`conf/web.xml` when it is `true`. It also adds `proxy_hide_header` for the CORS headers
+in `config/geoserver-location.conf`, so anything GeoServer still sends is dropped at
+nginx rather than reaching the client. Defaults to `false`, preserving current behaviour.
 
 > [!NOTE]
-> The entrypoint rewrites `web.xml` on container start, so an existing pod must be
-> restarted for a change to this value to take effect.
+> Both halves are delivered through ConfigMaps, and neither pod spec changes when the
+> value does — so `helm upgrade` alone will not apply it. The geoserver pod must restart
+> for the entrypoint to rewrite `web.xml`, and the nginx pod must restart because the
+> snippet is a `subPath` mount, which kubelet never refreshes.
+
+> [!CAUTION]
+> nginx is not an equivalent replacement for `CorsFilter`. It emits only
+> `Access-Control-Allow-Origin`, `-Allow-Headers` and `-Max-Age`, never
+> `-Expose-Headers`; and because those `add_header` directives lack the `always`
+> parameter, **no CORS headers are sent on 4xx/5xx responses**. Cross-origin callers
+> will see GeoServer errors as opaque CORS failures rather than real status codes.
+> Only enable this where nginx actually fronts GeoServer — with `nginx.enabled: false`
+> or the Dev-local route below, the flag removes CORS altogether.
 
 
 ## Deployment

--- a/helm/config/geoserver-location.conf
+++ b/helm/config/geoserver-location.conf
@@ -4,7 +4,7 @@ proxy_pass_header Set-Cookie;
 proxy_set_header X-Forwarded-Proto $scheme;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header X-Real-IP $remote_addr;
-{{- if .Values.disableCors }}
+{{- if eq (include "geoserver.disableCors" .) "true" }}
 
 # CORS is owned by this nginx layer, which adds its own headers at server level.
 # Drop any that GeoServer still sends so exactly one of each reaches the client.

--- a/helm/config/geoserver-location.conf
+++ b/helm/config/geoserver-location.conf
@@ -4,3 +4,14 @@ proxy_pass_header Set-Cookie;
 proxy_set_header X-Forwarded-Proto $scheme;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header X-Real-IP $remote_addr;
+{{- if .Values.disableCors }}
+
+# CORS is owned by this nginx layer, which adds its own headers at server level.
+# Drop any that GeoServer still sends so exactly one of each reaches the client.
+proxy_hide_header Access-Control-Allow-Origin;
+proxy_hide_header Access-Control-Allow-Credentials;
+proxy_hide_header Access-Control-Allow-Headers;
+proxy_hide_header Access-Control-Allow-Methods;
+proxy_hide_header Access-Control-Expose-Headers;
+proxy_hide_header Access-Control-Max-Age;
+{{- end }}

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -20,6 +20,19 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Normalise disableCors to the literal "true"/"false".
+
+Both halves of the flag have to agree, and they read it differently: the nginx
+snippet is gated by Go-template truthiness (where any non-empty string, "false"
+included, is true) while the geoserver image only acts on a case-insensitive
+"true". Deciding once here keeps a quoted `disableCors: "false"` from turning the
+nginx half on while leaving the geoserver half off.
+*/}}
+{{- define "geoserver.disableCors" -}}
+{{- eq (lower (toString (.Values.disableCors | default false))) "true" -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "geoserver.chart" -}}

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -18,7 +18,7 @@ data:
   UPDATE_INTERVAL: {{ .Values.updateInterval | default 120000 | quote }}
   INITIAL_MEMORY: {{ .Values.initialMemory | default "128M" | quote }}
   MAX_MEMORY: {{ .Values.maxMemory | default "756M" | quote }}
-  DISABLE_CORS: {{ .Values.disableCors | default false | quote }}
+  DISABLE_CORS: {{ include "geoserver.disableCors" . | quote }}
   GEOSERVER_DATA_DIR: {{ $fs.internalPvc.mountPath | quote }}
   POLLING_INTERVAL_MS: {{ .Values.sideCar.env.pollingIntervalMs | default 3000 | quote }}
   GEOSERVER_BASE_URL: {{ $serviceUrls.geoserverUrl | quote }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -183,13 +183,19 @@ nginx:
   nameOverride: "pp-geoserver-nginx"
   image:
     repository: common/nginx
-  extensions:
-    server:
-      enabled: true
-      fileName: geoserver-server.conf
-    location:
-      enabled: true
-      fileName: geoserver-location.conf
+  # The sub-chart reads these as `.Values.nginx.extensions.*` from inside itself,
+  # i.e. from its own top-level `nginx` values key -- so from here they have to be
+  # nested under `nginx.nginx`. Setting them at `nginx.extensions` leaves the
+  # sub-chart on its defaults (enabled: false), which mounts the snippets below
+  # without ever adding the `include` that loads them.
+  nginx:
+    extensions:
+      server:
+        enabled: true
+        fileName: geoserver-server.conf
+      location:
+        enabled: true
+        fileName: geoserver-location.conf
   port: 8080
   internalServicePort: 80
   targetPort: 8080

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -246,7 +246,11 @@ nginx:
   extraVolumes:
   - name: nginx-config
     configMap:
-      name: '{{ .Release.Name }}-nginx-configmap'
+      # Must match the name templates/configmap-nginx.yaml actually creates,
+      # which is `<release>-<chart>-nginx-configmap`. Without the chart name in
+      # here the nginx pod cannot mount the snippets and stays in
+      # ContainerCreating on a stock `helm install` of this chart.
+      name: '{{ .Release.Name }}-pp-geoserver-nginx-configmap'
 
   extraVolumeMounts:
   - name: nginx-config


### PR DESCRIPTION
| Question         | Answer |
| ---------------- | ------ |
| Bug fix          | ✖      |
| New feature      | ✔      |
| Breaking change  | ✖      |
| Deprecations     | ✖      |
| Documentation    | ✖      |
| Tests added      | ✖      |
| Chore            | ✖      |

Related issues: MAPCO-11397

> [!IMPORTANT]
> Stacked on #53 — based on `feat/disable-cors-flag`, which introduces `.Values.disableCors`. GitHub retargets this to `master` once #53 merges. Review/merge #53 first.

Further information:

Reinstates the `proxy_hide_header` line that a7ca382 (#16) removed, now gated on `.Values.disableCors` and widened to the rest of the CORS response headers GeoServer can emit.

### Why this is needed on top of #53

The nginx sub-chart's own `default.conf` adds `Access-Control-Allow-Origin` / `-Headers` / `-Max-Age` unconditionally at server level — there is no on/off switch. Through the public route (`/api/raster/v1`) that is the second header alongside GeoServer's, which is what produces the duplicate seen in the live deployment.

#53 alone gets the count to one in the normal case. This PR makes it hold regardless: the image's entrypoint only rewrites `web.xml` when it doesn't already exist (`web_cors()` skips the `sed` if `${CATALINA_HOME}/conf/web.xml` or an `EXTRA_CONFIG_DIR` copy is present), so this is the enforcement that doesn't depend on that branch being taken.

The snippet lands inside the root `location` block via the sub-chart's `nginx.extensions.location` include, and `helm/config/geoserver-location.conf` is rendered through `tpl`, so the gate works there.

### Verification

Two-layer nginx harness — a stub upstream emitting its own CORS headers behind a front server mirroring the sub-chart's server-level `add_header`, using the actual rendered `geoserver-location.conf`:

```
disableCors=false
    Access-Control-Allow-Origin: https://geoserver-says-this
    Access-Control-Allow-Credentials: true
    Access-Control-Max-Age: 7200
    Access-Control-Allow-Origin: *
    Access-Control-Allow-Headers: *
    --> Access-Control-Allow-Origin count: 2

disableCors=true
    Access-Control-Max-Age: 7200
    Access-Control-Allow-Origin: *
    Access-Control-Allow-Headers: *
    --> Access-Control-Allow-Origin count: 1
```

Two with the flag off (today's behaviour, preserved), exactly one with it on — and the survivor is the front-layer header. `nginx -t` passes on the rendered config; `helm lint` passes.